### PR TITLE
Updated implementation.md

### DIFF
--- a/src/pages/guides/authentication/ServerToServerAuthentication/implementation.md
+++ b/src/pages/guides/authentication/ServerToServerAuthentication/implementation.md
@@ -141,7 +141,7 @@ curl -X POST 'https://api.adobe.io/console/organizations/{orgId}/credentials/{cr
 
 
 ```curl
-curl -X POST 'https://api.adobe.io/console/organizations/{orgId}/credentials/{credentialId}/secrets/{uuid from step 9}' \
+curl -X DELETE 'https://api.adobe.io/console/organizations/{orgId}/credentials/{credentialId}/secrets/{uuid from step 9}' \
      -H 'Authorization: Bearer {ACCESS TOKEN GENERATED IN STEP 5}'
      -H 'x-api-key: {CLIENT ID FROM STEP 6}'
 ```


### PR DESCRIPTION
Updated the curl method from POST to DELETE for deleting client secrets with UUID, in implementation.md

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/AdobeDocs/adobe-dev-console/issues/90

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The documentation on OAuth Server-to-Server credential implementation guide has wrong curl syntax ('POST' instead of 'DELETE') for deleting existing client secret using UUID.
This fix would update the documentation to be more accurate.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested the DELETE endpoint via POSTMAN on personal project.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
