### PR TITLE
Fix typo in Server-to-Server auth scope parameter name

### DIFF
--- a/src/pages/guides/authentication/ServerToServerAuthentication/IMS.md
+++ b/src/pages/guides/authentication/ServerToServerAuthentication/IMS.md
@@ -15,7 +15,7 @@ Parameters can be sent in the body or as query parameters. Passing parameters in
 |`grant_type`|Yes|Value should always be `client_credentials`|
 |`client_id`|Yes|The Client ID obtained from the [Adobe Developer Console](/console)|
 |`client_secret`|Yes|The value of client secret obtained from the [Adobe Developer Console](/console)|
-|`scopes`|Yes|The list of comma separated scopes you are requesting. To see the scopes available to your credential, visit your project your the [Adobe Developer Console](/console)|
+|`scope`|Yes|The list of comma separated scopes you are requesting. To see the scopes available to your credential, visit your project your the [Adobe Developer Console](/console)|
 
 
 ### Request for OAuth Server-to-Server credential
@@ -38,7 +38,7 @@ curl -X POST 'https://ims-na1.adobelogin.com/ims/token/v3' \
 
 ## Refreshing access tokens
 
-You do not need a refresh token for OAuth Server-to-Server credentials. You can always request a new access token directly using your *client_id*, *client_secret*, and *scopes*. See [fetching access tokens](#fetching-access-tokens).
+You do not need a refresh token for OAuth Server-to-Server credentials. You can always request a new access token directly using your *client_id*, *client_secret*, and *scope*. See [fetching access tokens](#fetching-access-tokens).
 
 
 ## List all client secrets


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This page specifies list of parameters required by IMS Server-to-Server authentication OAuth flow. The name of parameter is `scopes` while `scope` is actually expected. Only the sample code contained correct spelling.

## Related Issue

---

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

It may prevent people from encountering a frustrating error indicating mismatch of scopes required/available, while the real cause is a mis-spelled parameter.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
